### PR TITLE
Updated line 56

### DIFF
--- a/R/read.nafoB.r
+++ b/R/read.nafoB.r
@@ -53,7 +53,7 @@ read.nafoB <- function(path, year = NULL, species = NULL, overwrite = FALSE){
         }
         
         fi <- list.files(un, full.names = T, recursive = T)
-        ma <- grep('NAFO', fi, value = T)
+        ma <- grep('nafo-21b-[0-9]+-[0-9]+/NAFO', fi, value = T)
         main <-fread(ma, data.table = F, stringsAsFactors = F)
         names(main) <- tolower(names(main))
         names(main)[which(names(main) == 'catches')] <- 'month_nk' # some years it is catches. other files use month_nk


### PR DESCRIPTION
if the user set `path` with a name containing *NAFO* (ex: `path` = *./NAFOB/raw/*, `ma` will have multiple matches on line 56 and line 57 won't work after that.